### PR TITLE
New spam bot block

### DIFF
--- a/Chatfilter
+++ b/Chatfilter
@@ -189,6 +189,7 @@ trade.*?accepted.*?with.*?for
 (?i)Unwanted( cc|-rs)
 (?i)Runewager(s)?
 (?i)Infernalmarket
+(?i)pengrs
 
 (?# Miscellaneous)
 (?i)s\s*e\s*l\s*l\s*r\s*s\s*0\s*7


### PR DESCRIPTION
Saw a few messages in my chat which were spamming these messages:

`Discord.Gg/pengrs  Blood Torva / Hard Mode Kits / Twisted Kits!`
`Discord.Gg/pengrs  Looking to get Dizana's quiver? Join now!`

Adding the discord name should block this bot.