### PR TITLE
Update on bot from PR #15

### DIFF
--- a/Chatfilter
+++ b/Chatfilter
@@ -189,7 +189,7 @@ trade.*?accepted.*?with.*?for
 (?i)Unwanted( cc|-rs)
 (?i)Runewager(s)?
 (?i)Infernalmarket
-(?i)pengrs
+(?i)peng(r)?(s)?
 
 (?# Miscellaneous)
 (?i)s\s*e\s*l\s*l\s*r\s*s\s*0\s*7

--- a/Chatfilter
+++ b/Chatfilter
@@ -189,7 +189,7 @@ trade.*?accepted.*?with.*?for
 (?i)Unwanted( cc|-rs)
 (?i)Runewager(s)?
 (?i)Infernalmarket
-(?i)peng(r)?(s)?
+(?i)\bpeng(r)?(s)?\b
 
 (?# Miscellaneous)
 (?i)s\s*e\s*l\s*l\s*r\s*s\s*0\s*7


### PR DESCRIPTION
The bot from the previous PR has changed it's string slightly. Making the `rs` portion of the string into reluctant quantifier capture groups should capture:

`pengrs`
`pengr`
`pengs`

Example of some of that bots messages as of today:

`Discord.Gg/peng  Looking to get Dizana's quiver? Join now!`
`Discord.Gg/peng  Blood Torva / Hard Mode Kits / Infernal capes!`
`Discord.Gg/peng  We offer Remote which means 0% Ban Rate!`
`Discord.Gg/peng  Tired of dying trying to get Quiver? Join now!`

I can potentially foresee them changing it to `pengosrs` in the future but I'll deal with that when or it it becomes an problem.