### PR TITLE
Interpunct symbol (Altcode 0183) & zoomgp specific advert

### DIFF
--- a/Chatfilter
+++ b/Chatfilter
@@ -187,6 +187,7 @@ trade.*?accepted.*?with.*?for
 (?i)(i|l)ceart(00|OO)7
 (?i)rushgp
 (?i)safegp
+(?i)zoomgp
 
 (?i)warning.*?is.*?a.*?hacker.*?do.*?not.*?add.*?him
 (?i).*?will.*?try.*?send.*?you.*?virus.*?over.*?discord
@@ -205,4 +206,4 @@ trade.*?accepted.*?with.*?for
 [âêîôûÂÊÎÔÛ]
 [ãñõÃÑØøÕ]
 [äëïöüÿÄËÏÖÜŸ]
-[ÐæÆœŒçÇß«»°]
+[ÐæÆœŒçÇß«»°·]


### PR DESCRIPTION
Adding zoomgp to specific adverts list & adding interpunct (altcode 0183) to misc symbols list. I think it's safe to assume anyone using an interpunct in runescape is almost certainly a spam bot.