### PR TITLE
Update Chatfilter

### DIFF
--- a/Chatfilter
+++ b/Chatfilter
@@ -158,6 +158,8 @@ trade.*?accepted.*?with.*?for
 (?i).*?discord\.gg.*?*C\s*H\s*E\s*A\s*P\s*.*
 (?i).*?discord\.gg.*?cheap.*
 (?i).*?discord\.gg.*?payment.*
+(?i).*?·.*
+
 (?i).*?07market.*
 (?i).*?rsgoods.*
 (?i).*banrate.*


### PR DESCRIPTION
The spammers started using the raised dot character (·) For example they say discord·gg
A character no one else uses.

If we filter this out this character, we can remove a lot of this and even future abuses (?i).*?·.*