### PR TITLE
Adding buy/sell of specific items, trash items

### DIFF
--- a/Chatfilter
+++ b/Chatfilter
@@ -90,7 +90,7 @@ trade.*?accepted.*?with.*?for
 
 (?# Buying specific items) (WIP)
 (?i)(buy|sell)(ing)?.*?(ely|tumenken|tumeken('s)?|shadow|scythe|vitur|tbow|twisted bow).*\d+[gkmb]
-(?i)(buy|sell)(ing)?.*?(burnt|burned|burning|crushed|fossilized|unwanted|unneeded) *?(gems|food|rubble|dung)
+(?i)(buy|sell)(ing)?.*?(burnt|burned|burning|crushed|fossilized|unwanted|unneeded|broken) *?(gems|food|rubble|dung)
 
 (?# Giveaways and events)
 (?i)quitting? .*? giving \d+ percent.*? (1|one) trade

--- a/Chatfilter
+++ b/Chatfilter
@@ -89,6 +89,8 @@ trade.*?accepted.*?with.*?for
 (?i)buying\s+\w+.*for\s+\d+\s*[mb].*best\s+offer.*get
 
 (?# Buying specific items) (WIP)
+(?i)(buy|sell)(ing)? (ely|tumenken|tumeken('s)?|shadow|scythe|vitur|tbow|twisted bow).*\d+[gkmb]
+(?i)(buy|sell)(ing)? (burnt|crushed|fossilized|unwanted|unneeded)?(gems|food|rubble|dung)
 
 
 (?# Giveaways and events)

--- a/Chatfilter
+++ b/Chatfilter
@@ -90,8 +90,7 @@ trade.*?accepted.*?with.*?for
 
 (?# Buying specific items) (WIP)
 (?i)(buy|sell)(ing)? (ely|tumenken|tumeken('s)?|shadow|scythe|vitur|tbow|twisted bow).*\d+[gkmb]
-(?i)(buy|sell)(ing)? (burnt|crushed|fossilized|unwanted|unneeded)?(gems|food|rubble|dung)
-
+(?i)(buy|sell)(ing)? (burnt|burned|burning|crushed|fossilized|unwanted|unneeded) (gems|food|rubble|dung)
 
 (?# Giveaways and events)
 (?i)quitting? .*? giving \d+ percent.*? (1|one) trade

--- a/Chatfilter
+++ b/Chatfilter
@@ -89,8 +89,8 @@ trade.*?accepted.*?with.*?for
 (?i)buying\s+\w+.*for\s+\d+\s*[mb].*best\s+offer.*get
 
 (?# Buying specific items) (WIP)
-(?i)(buy|sell)(ing)? (ely|tumenken|tumeken('s)?|shadow|scythe|vitur|tbow|twisted bow).*\d+[gkmb]
-(?i)(buy|sell)(ing)? (burnt|burned|burning|crushed|fossilized|unwanted|unneeded) (gems|food|rubble|dung)
+(?i)(buy|sell)(ing)? ?(ely|tumenken|tumeken('s)?|shadow|scythe|vitur|tbow|twisted bow).*\d+[gkmb]
+(?i)(buy|sell)(ing)? ?(burnt|burned|burning|crushed|fossilized|unwanted|unneeded) ?(gems|food|rubble|dung)
 
 (?# Giveaways and events)
 (?i)quitting? .*? giving \d+ percent.*? (1|one) trade

--- a/Chatfilter
+++ b/Chatfilter
@@ -89,8 +89,8 @@ trade.*?accepted.*?with.*?for
 (?i)buying\s+\w+.*for\s+\d+\s*[mb].*best\s+offer.*get
 
 (?# Buying specific items) (WIP)
-(?i)(buy|sell)(ing)?.*?(ely|tumenken|tumeken('s)?|shadow|scythe|vitur|tbow|twisted bow).*\d+[gkmb]
-(?i)(buy|sell)(ing)?.*?(burnt|burned|burning|crushed|fossilized|unwanted|unneeded|broken) *?(gems|food|rubble|dung)
+(?i)^(buy|sell)(ing)?[\w ]+(tumeken(s?)|tumenken['s]?|ely|shadow(s?)|scythe(s?)|vitur|tbow(s?)|twisted bow(s?)|inquis|inquisitor(s|'s)?|sigil(s?))+($|\W+?.*?(\d+[gkmb]|\d{2,}|mill|bill))
+(?i)^(buy|sell)(ing)?.*?(burnt|burned|burning|crushed|fossilized|unwanted|unneeded|broken) *?(gems|food|rubble|dung)
 
 (?# Giveaways and events)
 (?i)quitting? .*? giving \d+ percent.*? (1|one) trade

--- a/Chatfilter
+++ b/Chatfilter
@@ -89,8 +89,8 @@ trade.*?accepted.*?with.*?for
 (?i)buying\s+\w+.*for\s+\d+\s*[mb].*best\s+offer.*get
 
 (?# Buying specific items) (WIP)
-(?i)(buy|sell)(ing)? ?(ely|tumenken|tumeken('s)?|shadow|scythe|vitur|tbow|twisted bow).*\d+[gkmb]
-(?i)(buy|sell)(ing)? ?(burnt|burned|burning|crushed|fossilized|unwanted|unneeded) ?(gems|food|rubble|dung)
+(?i)(buy|sell)(ing)?.*?(ely|tumenken|tumeken('s)?|shadow|scythe|vitur|tbow|twisted bow).*\d+[gkmb]
+(?i)(buy|sell)(ing)?.*?(burnt|burned|burning|crushed|fossilized|unwanted|unneeded) *?(gems|food|rubble|dung)
 
 (?# Giveaways and events)
 (?i)quitting? .*? giving \d+ percent.*? (1|one) trade

--- a/Chatfilter
+++ b/Chatfilter
@@ -90,7 +90,7 @@ trade.*?accepted.*?with.*?for
 
 (?# Buying specific items) (WIP)
 (?i)^(buy|sell)(ing)?[\w ]+(tumeken(s?)|tumenken['s]?|ely|shadow(s?)|scythe(s?)|vitur|tbow(s?)|twisted bow(s?)|inquis|inquisitor(s|'s)?|sigil(s?))+($|\W+?.*?(\d+[gkmb]|\d{2,}|mill|bill))
-(?i)^(buy|sell)(ing)?.*?(burnt|burned|burning|crushed|fossilized|unwanted|unneeded|broken) *?(gems|food|rubble|dung)
+### (?i)^(buy|sell)(ing)?.*?(burnt|burned|burning|crushed|fossilized|unwanted|unneeded|broken) *?(gems|food|rubble|dung)
 
 (?# Giveaways and events)
 (?i)quitting? .*? giving \d+ percent.*? (1|one) trade


### PR DESCRIPTION
* Wanted to filter out some of the high-priced items that people frequently spam/lowball/lure, etc.
* Some people enjoy selling trash items to collectors, but the messages do get annoying and aren't really necessary. They aren't scams, but you're only getting maybe 500k back on a newly 99'd skill from burnt/broken/unusable items. Feel free to comment/strip that one out if you want, it's a personal preference.